### PR TITLE
Update the define of 'b'

### DIFF
--- a/docs/chapter03_DL-basics/3.2_linear-regression-scratch.md
+++ b/docs/chapter03_DL-basics/3.2_linear-regression-scratch.md
@@ -114,7 +114,7 @@ tensor([[-1.4239, -1.3788],
 
 ``` python
 w = torch.from_numpy(np.random.normal(0, 0.01, (num_inputs, 1)))
-b = torch.zeros(shape=(1,))
+b = torch.zeros(1, dtype=torch.float64)
 ```
 
 之后的模型训练中，需要对这些参数求梯度来迭代参数的值，因此我们要让它们的`requires_grad=True`。


### PR DESCRIPTION
torch.zeros(*size, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) → Tensor
size (int...) – a sequence of integers defining the shape of the output tensor. Can be a variable number of arguments or a collection like a list or tuple.

If use shape=(1,) will return an error. And if not define the type of b it will be error when using linreg function. 
(The specific error messages is: expected device cpu and dtype Double but got device cpu and dtype Float)
Because in linreg, torch.mm(X, w) is torch.float64, and b is torch.float32, they add up cannot return torch.float64.