### PR TITLE
fix lenet5 wrong Linear layer

### DIFF
--- a/code/chapter05_CNN/5.5_lenet.ipynb
+++ b/code/chapter05_CNN/5.5_lenet.ipynb
@@ -73,7 +73,7 @@
     "            nn.MaxPool2d(2, 2)\n",
     "        )\n",
     "        self.fc = nn.Sequential(\n",
-    "            nn.Linear(16*4*4, 120),\n",
+    "            nn.Linear(16*5*5, 120),\n",
     "            nn.Sigmoid(),\n",
     "            nn.Linear(120, 84),\n",
     "            nn.Sigmoid(),\n",


### PR DESCRIPTION
和英文版的以及原论文的比对了一下，确定这里的输入参数算错了。
https://github.com/dsgiitr/d2l-pytorch/blob/master/Ch08_Convolutional_Neural_Networks/Convolutional_Neural_Networks(LeNet).ipynb