### PR TITLE
修复size mismatch问题

### DIFF
--- a/code/chapter05_CNN/5.5_lenet.ipynb
+++ b/code/chapter05_CNN/5.5_lenet.ipynb
@@ -73,7 +73,7 @@
     "            nn.MaxPool2d(2, 2)\n",
     "        )\n",
     "        self.fc = nn.Sequential(\n",
-    "            nn.Linear(16*4*4, 120),\n",
+    "            nn.Linear(16*5*5, 120),\n",
     "            nn.Sigmoid(),\n",
     "            nn.Linear(120, 84),\n",
     "            nn.Sigmoid(),\n",


### PR DESCRIPTION
LeNet 卷积最后的结果为 `16@5x5` 的 tensor ，所以这里应该是 `16x5x5`